### PR TITLE
Update to latest rmagick

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
-    rmagick (2.16.0)
+    rmagick (4.1.1)
     sinatra (2.0.0)
       mustermann (~> 1.0)
       rack (~> 2.0)


### PR DESCRIPTION
`core/imagemagick` updated from 6.x to 7.0.9, and as part of the major version bump, ImageMagick has moved their header files from `include/ImageMagic-6/wand` to `include/ImageMagic-7/MagicWand`.  The version currently in the Gemfile (2.1.1) doesn't understand the change in directories and attempts to include `wand/MagickWand.h`, which has been moved to `MagicWand/MagickWand.h`. The latest version `4.1.1` corrects this.

Note, I haven't been able to evaluate the remainder of the module in which this is used and given that there have been two major version updates to Rmagick there is a good chance there are other errors buried behind this version bump.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>